### PR TITLE
Renamed table test fields for consistency

### DIFF
--- a/cmd/translate/main_grpc_integration_test.go
+++ b/cmd/translate/main_grpc_integration_test.go
@@ -88,13 +88,13 @@ func Test_UploadTranslationFile_gRPC(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		req  *pb.UploadTranslationFileRequest
-		name string
-		want codes.Code
+		input    *pb.UploadTranslationFileRequest
+		name     string
+		expected codes.Code
 	}{
 		{
 			name: "Happy path",
-			req: &pb.UploadTranslationFileRequest{
+			input: &pb.UploadTranslationFileRequest{
 				Language: "lv-lv",
 				Data: []byte(`{
 						"language":"lv-lv",
@@ -110,11 +110,11 @@ func Test_UploadTranslationFile_gRPC(t *testing.T) {
 				 }`),
 				Schema: pb.Schema_GO,
 			},
-			want: codes.OK,
+			expected: codes.OK,
 		},
 		{
 			name: "Missing language",
-			req: &pb.UploadTranslationFileRequest{
+			input: &pb.UploadTranslationFileRequest{
 				Data: []byte(`{
 						"messages":[
 							 {
@@ -128,16 +128,16 @@ func Test_UploadTranslationFile_gRPC(t *testing.T) {
 				 }`),
 				Schema: pb.Schema_GO,
 			},
-			want: codes.InvalidArgument,
+			expected: codes.InvalidArgument,
 		},
 		{
-			name: "Missing data",
-			req:  &pb.UploadTranslationFileRequest{Language: "lv-lv"},
-			want: codes.InvalidArgument,
+			name:     "Missing data",
+			input:    &pb.UploadTranslationFileRequest{Language: "lv-lv"},
+			expected: codes.InvalidArgument,
 		},
 		{
 			name: "Invalid language",
-			req: &pb.UploadTranslationFileRequest{
+			input: &pb.UploadTranslationFileRequest{
 				Language: "xyz-ZY-Latn",
 				Data: []byte(`{
 						"messages":[
@@ -152,7 +152,7 @@ func Test_UploadTranslationFile_gRPC(t *testing.T) {
 				 }`),
 				Schema: pb.Schema_GO,
 			},
-			want: codes.InvalidArgument,
+			expected: codes.InvalidArgument,
 		},
 	}
 
@@ -161,9 +161,9 @@ func Test_UploadTranslationFile_gRPC(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			_, err := client.UploadTranslationFile(context.Background(), tt.req)
+			_, err := client.UploadTranslationFile(context.Background(), tt.input)
 
-			assert.Equal(t, tt.want, status.Code(err))
+			assert.Equal(t, tt.expected, status.Code(err))
 		})
 	}
 }
@@ -172,19 +172,19 @@ func Test_DownloadTranslationFile_gRPC(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		req  *pb.DownloadTranslationFileRequest
-		name string
-		want codes.Code
+		input    *pb.DownloadTranslationFileRequest
+		name     string
+		expected codes.Code
 	}{
 		{
-			name: "Happy path",
-			req:  &pb.DownloadTranslationFileRequest{Language: "lv-lv"},
-			want: codes.OK,
+			name:     "Happy path",
+			input:    &pb.DownloadTranslationFileRequest{Language: "lv-lv"},
+			expected: codes.OK,
 		},
 		{
-			name: "Invalid argument",
-			req:  &pb.DownloadTranslationFileRequest{},
-			want: codes.InvalidArgument,
+			name:     "Invalid argument",
+			input:    &pb.DownloadTranslationFileRequest{},
+			expected: codes.InvalidArgument,
 		},
 	}
 
@@ -193,9 +193,9 @@ func Test_DownloadTranslationFile_gRPC(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			_, err := client.DownloadTranslationFile(context.Background(), tt.req)
+			_, err := client.DownloadTranslationFile(context.Background(), tt.input)
 
-			assert.Equal(t, tt.want, status.Code(err))
+			assert.Equal(t, tt.expected, status.Code(err))
 		})
 	}
 }

--- a/cmd/translate/main_grpc_integration_test.go
+++ b/cmd/translate/main_grpc_integration_test.go
@@ -163,7 +163,8 @@ func Test_UploadTranslationFile_gRPC(t *testing.T) {
 
 			_, err := client.UploadTranslationFile(context.Background(), tt.input)
 
-			assert.Equal(t, tt.expected, status.Code(err))
+			actual := status.Code(err)
+			assert.Equal(t, tt.expected, actual)
 		})
 	}
 }
@@ -195,7 +196,8 @@ func Test_DownloadTranslationFile_gRPC(t *testing.T) {
 
 			_, err := client.DownloadTranslationFile(context.Background(), tt.input)
 
-			assert.Equal(t, tt.expected, status.Code(err))
+			actual := status.Code(err)
+			assert.Equal(t, tt.expected, actual)
 		})
 	}
 }

--- a/cmd/translate/main_rest_integration_test.go
+++ b/cmd/translate/main_rest_integration_test.go
@@ -118,7 +118,8 @@ func Test_UploadTranslationFile_REST(t *testing.T) {
 			}
 			defer resp.Body.Close()
 
-			assert.EqualValues(t, tt.expected, resp.StatusCode)
+			actual := resp.StatusCode
+			assert.EqualValues(t, tt.expected, actual)
 		})
 	}
 }
@@ -179,7 +180,8 @@ func Test_DownloadTranslationFile_REST(t *testing.T) {
 			}
 			defer resp.Body.Close()
 
-			assert.EqualValues(t, tt.expected, resp.StatusCode)
+			actual := resp.StatusCode
+			assert.EqualValues(t, tt.expected, actual)
 		})
 	}
 }

--- a/cmd/translate/main_rest_integration_test.go
+++ b/cmd/translate/main_rest_integration_test.go
@@ -43,13 +43,13 @@ func Test_UploadTranslationFile_REST(t *testing.T) {
 	}
 
 	tests := []struct {
-		name   string
-		params params
-		want   uint
+		name     string
+		input    params
+		expected uint
 	}{
 		{
 			name: "Happy Path",
-			params: params{
+			input: params{
 				fileSchema: "GO",
 				path:       "v1/files/lv-LV",
 				data: []byte(`{
@@ -64,11 +64,11 @@ func Test_UploadTranslationFile_REST(t *testing.T) {
 					]
 				}`),
 			},
-			want: http.StatusOK,
+			expected: http.StatusOK,
 		},
 		{
 			name: "Invalid argument",
-			params: params{
+			input: params{
 				fileSchema: "GO",
 				path:       "v1/files/lv-LV-asd",
 				data: []byte(`{
@@ -83,7 +83,7 @@ func Test_UploadTranslationFile_REST(t *testing.T) {
 					]
 				}`),
 			},
-			want: http.StatusBadRequest,
+			expected: http.StatusBadRequest,
 		},
 	}
 	for _, tt := range tests {
@@ -92,16 +92,16 @@ func Test_UploadTranslationFile_REST(t *testing.T) {
 			t.Parallel()
 
 			query := url.Values{}
-			query.Add("schema", tt.params.fileSchema)
+			query.Add("schema", tt.input.fileSchema)
 
 			u := url.URL{
 				Scheme:   "http",
 				Host:     host + ":" + port,
-				Path:     tt.params.path,
+				Path:     tt.input.path,
 				RawQuery: query.Encode(),
 			}
 
-			body, contentType, err := attachFile(tt.params.data, t)
+			body, contentType, err := attachFile(tt.input.data, t)
 			if !assert.NoError(t, err) {
 				return
 			}
@@ -118,7 +118,7 @@ func Test_UploadTranslationFile_REST(t *testing.T) {
 			}
 			defer resp.Body.Close()
 
-			assert.EqualValues(t, tt.want, resp.StatusCode)
+			assert.EqualValues(t, tt.expected, resp.StatusCode)
 		})
 	}
 }
@@ -132,25 +132,25 @@ func Test_DownloadTranslationFile_REST(t *testing.T) {
 	}
 
 	tests := []struct {
-		name   string
-		params params
-		want   uint
+		name     string
+		input    params
+		expected uint
 	}{
 		{
 			name: "Happy path",
-			params: params{
+			input: params{
 				fileSchema: "GO",
 				path:       "v1/files/lv-LV",
 			},
-			want: http.StatusOK,
+			expected: http.StatusOK,
 		},
 		{
 			name: "Invalid argument",
-			params: params{
+			input: params{
 				fileSchema: "GO",
 				path:       "v1/files/lv-LV-asd",
 			},
-			want: http.StatusBadRequest,
+			expected: http.StatusBadRequest,
 		},
 	}
 	for _, tt := range tests {
@@ -159,12 +159,12 @@ func Test_DownloadTranslationFile_REST(t *testing.T) {
 			t.Parallel()
 
 			query := url.Values{}
-			query.Add("schema", tt.params.fileSchema)
+			query.Add("schema", tt.input.fileSchema)
 
 			u := url.URL{
 				Scheme:   "http",
 				Host:     host + ":" + port,
-				Path:     tt.params.path,
+				Path:     tt.input.path,
 				RawQuery: query.Encode(),
 			}
 
@@ -179,7 +179,7 @@ func Test_DownloadTranslationFile_REST(t *testing.T) {
 			}
 			defer resp.Body.Close()
 
-			assert.EqualValues(t, tt.want, resp.StatusCode)
+			assert.EqualValues(t, tt.expected, resp.StatusCode)
 		})
 	}
 }

--- a/pkg/convert/arb_test.go
+++ b/pkg/convert/arb_test.go
@@ -14,14 +14,14 @@ func Test_FromArb(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		want    model.Messages
-		wantErr error
-		name    string
-		data    []byte
+		expected    model.Messages
+		expectedErr error
+		name        string
+		input       []byte
 	}{
 		{
 			name: "Combination of messages",
-			data: []byte(`
+			input: []byte(`
 			{
 				"title": "Hello World!",
 				"@title": {
@@ -38,7 +38,7 @@ func Test_FromArb(t *testing.T) {
 				},
 				"farewell": "Goodbye friend"
 			}`),
-			want: model.Messages{
+			expected: model.Messages{
 				Messages: []model.Message{
 					{
 						ID:          "title",
@@ -55,31 +55,31 @@ func Test_FromArb(t *testing.T) {
 					},
 				},
 			},
-			wantErr: nil,
+			expectedErr: nil,
 		},
 		{
 			name: "Wrong value type for @title",
-			data: []byte(`
+			input: []byte(`
 			{
 				"title": "Hello World!",
 				"@title": "Message to greet the World"
 			}`),
-			wantErr: errors.New("expected a map, got 'string'"),
+			expectedErr: errors.New("expected a map, got 'string'"),
 		},
 		{
 			name: "Wrong value type for greeting key",
-			data: []byte(`
+			input: []byte(`
 			{
 				"title": "Hello World!",
 				"greeting": {
 					"description": "Needed for greeting"
 				}
 			}`),
-			wantErr: errors.New("unsupported value type 'map[string]interface {}' for key 'greeting'"),
+			expectedErr: errors.New("unsupported value type 'map[string]interface {}' for key 'greeting'"),
 		},
 		{
 			name: "Wrong value type for description key",
-			data: []byte(`
+			input: []byte(`
 			{
 				"title": "Hello World!",
 				"@title": {
@@ -88,11 +88,11 @@ func Test_FromArb(t *testing.T) {
 					}
 				}
 			}`),
-			wantErr: errors.New("'Description' expected type 'string', got unconvertible type 'map[string]interface {}'"),
+			expectedErr: errors.New("'Description' expected type 'string', got unconvertible type 'map[string]interface {}'"),
 		},
 		{
 			name: "With locale",
-			data: []byte(`
+			input: []byte(`
       {
         "@@locale": "en",
         "title": "Hello World!",
@@ -100,7 +100,7 @@ func Test_FromArb(t *testing.T) {
           "description": "Message to greet the World"
         }
       }`),
-			want: model.Messages{
+			expected: model.Messages{
 				Language: language.English,
 				Messages: []model.Message{
 					{
@@ -110,11 +110,11 @@ func Test_FromArb(t *testing.T) {
 					},
 				},
 			},
-			wantErr: nil,
+			expectedErr: nil,
 		},
 		{
 			name: "With malformed locale",
-			data: []byte(`
+			input: []byte(`
       {
         "@@locale": "asd-gh-jk",
         "title": "Hello World!",
@@ -122,11 +122,11 @@ func Test_FromArb(t *testing.T) {
           "description": "Message to greet the World"
         }
       }`),
-			wantErr: fmt.Errorf("language: tag is not well-formed"),
+			expectedErr: fmt.Errorf("language: tag is not well-formed"),
 		},
 		{
 			name: "With wrong value type for locale",
-			data: []byte(`
+			input: []byte(`
       {
         "@@locale": {
           "tag": "fr-FR"
@@ -136,7 +136,7 @@ func Test_FromArb(t *testing.T) {
           "description": "Message to greet the World"
         }
       }`),
-			wantErr: fmt.Errorf("unsupported value type 'map[string]interface {}' for key '@@locale'"),
+			expectedErr: fmt.Errorf("unsupported value type 'map[string]interface {}' for key '@@locale'"),
 		},
 	}
 	for _, tt := range tests {
@@ -144,9 +144,9 @@ func Test_FromArb(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			res, err := FromArb(tt.data)
-			if tt.wantErr != nil {
-				assert.ErrorContains(t, err, tt.wantErr.Error())
+			actual, err := FromArb(tt.input)
+			if tt.expectedErr != nil {
+				assert.ErrorContains(t, err, tt.expectedErr.Error())
 				return
 			}
 
@@ -154,8 +154,8 @@ func Test_FromArb(t *testing.T) {
 				return
 			}
 
-			assert.Equal(t, tt.want.Language, res.Language)
-			assert.ElementsMatch(t, tt.want.Messages, res.Messages)
+			assert.Equal(t, tt.expected.Language, actual.Language)
+			assert.ElementsMatch(t, tt.expected.Messages, actual.Messages)
 		})
 	}
 }
@@ -178,7 +178,7 @@ func Test_ToArb(t *testing.T) {
 		},
 	}
 
-	want := []byte(`
+	expected := []byte(`
 	{
 		"@@locale":"fr",
 		"title":"Hello World!",
@@ -188,10 +188,10 @@ func Test_ToArb(t *testing.T) {
 		"greeting":"Welcome {user}"
 	}`)
 
-	res, err := ToArb(messages)
+	actual, err := ToArb(messages)
 	if !assert.NoError(t, err) {
 		return
 	}
 
-	assert.JSONEq(t, string(want), string(res))
+	assert.JSONEq(t, string(expected), string(actual))
 }

--- a/pkg/convert/go_test.go
+++ b/pkg/convert/go_test.go
@@ -1,8 +1,6 @@
 package convert
 
 import (
-	"bytes"
-	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -52,22 +50,18 @@ func TestToGo(t *testing.T) {
 		]
 	}`)
 
-	buffer := new(bytes.Buffer)
-
-	if !assert.NoError(t, json.Compact(buffer, expected)) {
+	actual, err := ToGo(modelMsg)
+	if !assert.NoError(t, err) {
 		return
 	}
 
-	result, err := ToGo(modelMsg)
-
-	assert.NoError(t, err)
-	assert.Equal(t, buffer.Bytes(), result)
+	assert.JSONEq(t, string(expected), string(actual))
 }
 
 func TestFromGo(t *testing.T) {
 	t.Parallel()
 
-	b := []byte(`
+	input := []byte(`
 	{
 		"language":"en",
 		"messages":[
@@ -87,14 +81,10 @@ func TestFromGo(t *testing.T) {
 		]
 	}`)
 
-	buffer := new(bytes.Buffer)
-
-	if !assert.NoError(t, json.Compact(buffer, b)) {
+	actual, err := FromGo(input)
+	if !assert.NoError(t, err) {
 		return
 	}
 
-	result, err := FromGo(buffer.Bytes())
-
-	assert.NoError(t, err)
-	assert.Equal(t, modelMsg, result)
+	assert.Equal(t, modelMsg, actual)
 }

--- a/pkg/convert/json_nglocalize_test.go
+++ b/pkg/convert/json_nglocalize_test.go
@@ -13,14 +13,14 @@ func Test_FromNgLocalize(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		wantErr error
-		data    []byte
-		name    string
-		want    model.Messages
+		expectedErr error
+		input       []byte
+		name        string
+		expected    model.Messages
 	}{
 		{
 			name: "All OK",
-			data: []byte(`
+			input: []byte(`
       {
         "locale": "fr",
         "translations": {
@@ -28,7 +28,7 @@ func Test_FromNgLocalize(t *testing.T) {
           "Welcome": "Bienvenue"
         }
       }`),
-			want: model.Messages{
+			expected: model.Messages{
 				Language: language.French,
 				Messages: []model.Message{
 					{
@@ -41,11 +41,11 @@ func Test_FromNgLocalize(t *testing.T) {
 					},
 				},
 			},
-			wantErr: nil,
+			expectedErr: nil,
 		},
 		{
 			name: "Malformed language tag",
-			data: []byte(`
+			input: []byte(`
       {
         "locale": "xyz-ZY-Latn",
         "translations": {
@@ -53,7 +53,7 @@ func Test_FromNgLocalize(t *testing.T) {
           "Welcome": "Bienvenue"
         }
       }`),
-			wantErr: fmt.Errorf("language: subtag \"xyz\" is well-formed but unknown"),
+			expectedErr: fmt.Errorf("language: subtag \"xyz\" is well-formed but unknown"),
 		},
 	}
 	for _, tt := range tests {
@@ -61,10 +61,10 @@ func Test_FromNgLocalize(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			messages, err := FromNgLocalize(tt.data)
+			actual, err := FromNgLocalize(tt.input)
 
-			if tt.wantErr != nil {
-				assert.ErrorContains(t, err, tt.wantErr.Error())
+			if tt.expectedErr != nil {
+				assert.ErrorContains(t, err, tt.expectedErr.Error())
 				return
 			}
 
@@ -72,8 +72,8 @@ func Test_FromNgLocalize(t *testing.T) {
 				return
 			}
 
-			assert.Equal(t, tt.want.Language, messages.Language)
-			assert.ElementsMatch(t, tt.want.Messages, messages.Messages)
+			assert.Equal(t, tt.expected.Language, actual.Language)
+			assert.ElementsMatch(t, tt.expected.Messages, actual.Messages)
 		})
 	}
 }
@@ -82,14 +82,14 @@ func Test_ToNgLocalize(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name     string
-		want     []byte
-		wantErr  error
-		messages model.Messages
+		name        string
+		expected    []byte
+		expectedErr error
+		input       model.Messages
 	}{
 		{
 			name: "All OK",
-			want: []byte(`
+			expected: []byte(`
       {
         "locale": "en",
         "translations": {
@@ -98,7 +98,7 @@ func Test_ToNgLocalize(t *testing.T) {
           "Feedback": "We appreciate your feedback. Thank you for using our service."
         }
       }`),
-			messages: model.Messages{
+			input: model.Messages{
 				Language: language.English,
 				Messages: []model.Message{
 					{
@@ -117,7 +117,7 @@ func Test_ToNgLocalize(t *testing.T) {
 					},
 				},
 			},
-			wantErr: nil,
+			expectedErr: nil,
 		},
 	}
 	for _, tt := range tests {
@@ -125,10 +125,10 @@ func Test_ToNgLocalize(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			result, err := ToNgLocalize(tt.messages)
+			actual, err := ToNgLocalize(tt.input)
 
-			if tt.wantErr != nil {
-				assert.ErrorContains(t, err, tt.wantErr.Error())
+			if tt.expectedErr != nil {
+				assert.ErrorContains(t, err, tt.expectedErr.Error())
 				return
 			}
 
@@ -136,7 +136,7 @@ func Test_ToNgLocalize(t *testing.T) {
 				return
 			}
 
-			assert.JSONEq(t, string(tt.want), string(result))
+			assert.JSONEq(t, string(tt.expected), string(actual))
 		})
 	}
 }

--- a/pkg/convert/json_ngxtranslate_test.go
+++ b/pkg/convert/json_ngxtranslate_test.go
@@ -13,13 +13,13 @@ func Test_FromNgxTranslate(t *testing.T) {
 
 	tests := []struct {
 		name        string
-		serialized  []byte
+		input       []byte
 		expectedErr error
 		expected    model.Messages
 	}{
 		{
-			name:       "Not nested",
-			serialized: []byte(`{"message":"example"}`),
+			name:  "Not nested",
+			input: []byte(`{"message":"example"}`),
 			expected: model.Messages{
 				Messages: []model.Message{
 					{
@@ -30,8 +30,8 @@ func Test_FromNgxTranslate(t *testing.T) {
 			},
 		},
 		{
-			name:       "Nested normally",
-			serialized: []byte(`{"message":{"example":"message1"}}`),
+			name:  "Nested normally",
+			input: []byte(`{"message":{"example":"message1"}}`),
 			expected: model.Messages{
 				Messages: []model.Message{
 					{
@@ -42,8 +42,8 @@ func Test_FromNgxTranslate(t *testing.T) {
 			},
 		},
 		{
-			name:       "Nested with dot",
-			serialized: []byte(`{"message.example":"message1"}`),
+			name:  "Nested with dot",
+			input: []byte(`{"message.example":"message1"}`),
 			expected: model.Messages{
 				Messages: []model.Message{
 					{
@@ -54,8 +54,8 @@ func Test_FromNgxTranslate(t *testing.T) {
 			},
 		},
 		{
-			name:       "Nested mixed",
-			serialized: []byte(`{"message.example":"message1","msg":{"example":"message2"}}`),
+			name:  "Nested mixed",
+			input: []byte(`{"message.example":"message1","msg":{"example":"message2"}}`),
 			expected: model.Messages{
 				Messages: []model.Message{
 					{
@@ -71,13 +71,13 @@ func Test_FromNgxTranslate(t *testing.T) {
 		},
 		{
 			name:        "Unsupported value type",
-			serialized:  []byte(`{"message": 1.0}`),
+			input:       []byte(`{"message": 1.0}`),
 			expectedErr: fmt.Errorf("traverse ngx-translate: unsupported value type %T for key %s", 1.0, "message"),
 			expected:    model.Messages{},
 		},
 		{
 			name:        "Invalid JSON",
-			serialized:  []byte(`{"message": "example"`),
+			input:       []byte(`{"message": "example"`),
 			expectedErr: fmt.Errorf("unmarshal from ngx-translate to model.Messages: unexpected end of JSON input"),
 			expected:    model.Messages{},
 		},
@@ -88,14 +88,14 @@ func Test_FromNgxTranslate(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			result, err := FromNgxTranslate(tt.serialized)
+			actual, err := FromNgxTranslate(tt.input)
 			if err != nil {
 				assert.Equal(t, tt.expectedErr, fmt.Errorf(err.Error()))
 				return
 			}
 
-			assert.Equal(t, tt.expected.Language, result.Language)
-			assert.ElementsMatch(t, tt.expected.Messages, result.Messages)
+			assert.Equal(t, tt.expected.Language, actual.Language)
+			assert.ElementsMatch(t, tt.expected.Messages, actual.Messages)
 		})
 	}
 }
@@ -103,7 +103,7 @@ func Test_FromNgxTranslate(t *testing.T) {
 func Test_ToNgxTranslate(t *testing.T) {
 	t.Parallel()
 
-	messages := model.Messages{
+	input := model.Messages{
 		Messages: []model.Message{
 			{
 				ID:      "message",
@@ -117,11 +117,11 @@ func Test_ToNgxTranslate(t *testing.T) {
 	}
 
 	expected := []byte(`{"message":"example","message.example":"message1"}`)
-	result, err := ToNgxTranslate(messages)
+	actual, err := ToNgxTranslate(input)
 
 	if !assert.NoError(t, err) {
 		return
 	}
 
-	assert.Equal(t, expected, result)
+	assert.Equal(t, expected, actual)
 }

--- a/pkg/convert/xliff12_test.go
+++ b/pkg/convert/xliff12_test.go
@@ -13,14 +13,14 @@ func Test_FromXliff12(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name    string
-		wantErr error
-		data    []byte
-		want    model.Messages
+		name        string
+		expectedErr error
+		input       []byte
+		expected    model.Messages
 	}{
 		{
 			name: "All OK",
-			data: []byte(`<?xml version="1.0" encoding="UTF-8"?>
+			input: []byte(`<?xml version="1.0" encoding="UTF-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
   <file source-language="en" target-language="fr" datatype="plaintext" original="ng2.template">
     <body>
@@ -34,7 +34,7 @@ func Test_FromXliff12(t *testing.T) {
     </body>
   </file>
 </xliff>`),
-			want: model.Messages{
+			expected: model.Messages{
 				Language: language.English,
 				Messages: []model.Message{
 					{
@@ -48,11 +48,11 @@ func Test_FromXliff12(t *testing.T) {
 					},
 				},
 			},
-			wantErr: nil,
+			expectedErr: nil,
 		},
 		{
 			name: "Malformed language tag",
-			data: []byte(`<?xml version="1.0" encoding="UTF-8"?>
+			input: []byte(`<?xml version="1.0" encoding="UTF-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
   <file source-language="xyz-ZY-Latn" target-language="fr" datatype="plaintext" original="ng2.template">
     <body>
@@ -66,7 +66,7 @@ func Test_FromXliff12(t *testing.T) {
     </body>
   </file>
 </xliff>`),
-			wantErr: fmt.Errorf("language: subtag \"xyz\" is well-formed but unknown"),
+			expectedErr: fmt.Errorf("language: subtag \"xyz\" is well-formed but unknown"),
 		},
 	}
 	for _, tt := range tests {
@@ -74,10 +74,10 @@ func Test_FromXliff12(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			messages, err := FromXliff12(tt.data)
+			actual, err := FromXliff12(tt.input)
 
-			if tt.wantErr != nil {
-				assert.ErrorContains(t, err, tt.wantErr.Error())
+			if tt.expectedErr != nil {
+				assert.ErrorContains(t, err, tt.expectedErr.Error())
 				return
 			}
 
@@ -85,8 +85,8 @@ func Test_FromXliff12(t *testing.T) {
 				return
 			}
 
-			assert.Equal(t, tt.want.Language, messages.Language)
-			assert.ElementsMatch(t, tt.want.Messages, messages.Messages)
+			assert.Equal(t, tt.expected.Language, actual.Language)
+			assert.ElementsMatch(t, tt.expected.Messages, actual.Messages)
 		})
 	}
 }
@@ -95,14 +95,14 @@ func Test_ToXliff12(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name     string
-		want     []byte
-		wantErr  error
-		messages model.Messages
+		name        string
+		expected    []byte
+		expectedErr error
+		input       model.Messages
 	}{
 		{
 			name: "All OK",
-			want: []byte(`<?xml version="1.0" encoding="UTF-8"?>
+			expected: []byte(`<?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
   <file source-language="en">
     <body>
@@ -120,8 +120,8 @@ func Test_ToXliff12(t *testing.T) {
     </body>
   </file>
 </xliff>`),
-			wantErr: nil,
-			messages: model.Messages{
+			expectedErr: nil,
+			input: model.Messages{
 				Language: language.English,
 				Messages: []model.Message{
 					{
@@ -147,10 +147,10 @@ func Test_ToXliff12(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			result, err := ToXliff12(tt.messages)
+			actual, err := ToXliff12(tt.input)
 
-			if tt.wantErr != nil {
-				assert.ErrorContains(t, err, tt.wantErr.Error())
+			if tt.expectedErr != nil {
+				assert.ErrorContains(t, err, tt.expectedErr.Error())
 				return
 			}
 
@@ -158,7 +158,7 @@ func Test_ToXliff12(t *testing.T) {
 				return
 			}
 
-			assertEqualXml(t, tt.want, result)
+			assertEqualXml(t, tt.expected, actual)
 		})
 	}
 }

--- a/pkg/convert/xliff2_test.go
+++ b/pkg/convert/xliff2_test.go
@@ -24,14 +24,14 @@ func TestFromXliff2(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name    string
-		wantErr error
-		data    []byte
-		want    model.Messages
+		name        string
+		expectedErr error
+		input       []byte
+		expected    model.Messages
 	}{
 		{
 			name: "All OK",
-			data: []byte(`<?xml version="1.0" encoding="UTF-8"?>
+			input: []byte(`<?xml version="1.0" encoding="UTF-8"?>
 <xliff version="2.0" xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en" trgLang="fr">
   <file id="ngi18n" original="ng.template">
     <unit id="common.welcome">
@@ -55,7 +55,7 @@ func TestFromXliff2(t *testing.T) {
     </unit>
   </file>
 </xliff>`),
-			want: model.Messages{
+			expected: model.Messages{
 				Language: language.English,
 				Messages: []model.Message{
 					{
@@ -69,11 +69,11 @@ func TestFromXliff2(t *testing.T) {
 					},
 				},
 			},
-			wantErr: nil,
+			expectedErr: nil,
 		},
 		{
 			name: "Malformed language tag",
-			data: []byte(`<?xml version="1.0" encoding="UTF-8"?>
+			input: []byte(`<?xml version="1.0" encoding="UTF-8"?>
 <xliff version="2.0" xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="xyz-ZY-Latn" trgLang="fr">
   <file id="ngi18n" original="ng.template">
     <unit id="common.welcome">
@@ -97,7 +97,7 @@ func TestFromXliff2(t *testing.T) {
     </unit>
   </file>
 </xliff>`),
-			wantErr: fmt.Errorf("language: subtag \"xyz\" is well-formed but unknown"),
+			expectedErr: fmt.Errorf("language: subtag \"xyz\" is well-formed but unknown"),
 		},
 	}
 	for _, tt := range tests {
@@ -105,9 +105,9 @@ func TestFromXliff2(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			result, err := FromXliff2(tt.data)
-			if tt.wantErr != nil {
-				assert.ErrorContains(t, err, tt.wantErr.Error())
+			actual, err := FromXliff2(tt.input)
+			if tt.expectedErr != nil {
+				assert.ErrorContains(t, err, tt.expectedErr.Error())
 				return
 			}
 
@@ -115,8 +115,8 @@ func TestFromXliff2(t *testing.T) {
 				return
 			}
 
-			assert.Equal(t, tt.want.Language, result.Language)
-			assert.ElementsMatch(t, tt.want.Messages, result.Messages)
+			assert.Equal(t, tt.expected.Language, actual.Language)
+			assert.ElementsMatch(t, tt.expected.Messages, actual.Messages)
 		})
 	}
 }
@@ -125,14 +125,14 @@ func Test_ToXliff2(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name     string
-		want     []byte
-		wantErr  error
-		messages model.Messages
+		name        string
+		expected    []byte
+		expectedErr error
+		input       model.Messages
 	}{
 		{
 			name: "All OK",
-			want: []byte(`<?xml version="1.0" encoding="UTF-8"?>
+			expected: []byte(`<?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="en">
   <file>
     <unit id="Welcome">
@@ -158,8 +158,8 @@ func Test_ToXliff2(t *testing.T) {
     </unit>
   </file>
 </xliff>`),
-			wantErr: nil,
-			messages: model.Messages{
+			expectedErr: nil,
+			input: model.Messages{
 				Language: language.English,
 				Messages: []model.Message{
 					{
@@ -185,10 +185,10 @@ func Test_ToXliff2(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			result, err := ToXliff2(tt.messages)
+			actual, err := ToXliff2(tt.input)
 
-			if tt.wantErr != nil {
-				assert.ErrorContains(t, err, tt.wantErr.Error())
+			if tt.expectedErr != nil {
+				assert.ErrorContains(t, err, tt.expectedErr.Error())
 				return
 			}
 
@@ -196,7 +196,7 @@ func Test_ToXliff2(t *testing.T) {
 				return
 			}
 
-			assertEqualXml(t, tt.want, result)
+			assertEqualXml(t, tt.expected, actual)
 		})
 	}
 }

--- a/pkg/translate/translate_test.go
+++ b/pkg/translate/translate_test.go
@@ -13,36 +13,36 @@ func Test_ParseUploadParams(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		req     *pb.UploadTranslationFileRequest
-		wantErr error
-		name    string
+		input       *pb.UploadTranslationFileRequest
+		expectedErr error
+		name        string
 	}{
 		{
 			name: "Happy Path",
-			req: &pb.UploadTranslationFileRequest{
+			input: &pb.UploadTranslationFileRequest{
 				Language: "lv-LV",
 				Data:     []byte(`{"key":"value"}`),
 				Schema:   pb.Schema_GO,
 			},
-			wantErr: nil,
+			expectedErr: nil,
 		},
 		{
 			name: "Malformed language tag",
-			req: &pb.UploadTranslationFileRequest{
+			input: &pb.UploadTranslationFileRequest{
 				Language: "xyz-ZY-Latn",
 				Data:     []byte(`{"key":"value"}`),
 				Schema:   pb.Schema_GO,
 			},
-			wantErr: errors.New("subtag \"xyz\" is well-formed but unknown"),
+			expectedErr: errors.New("subtag \"xyz\" is well-formed but unknown"),
 		},
 		{
 			name: "Missing language tag",
-			req: &pb.UploadTranslationFileRequest{
+			input: &pb.UploadTranslationFileRequest{
 				Language: "",
 				Data:     []byte(`{"key":"value"}`),
 				Schema:   pb.Schema_GO,
 			},
-			wantErr: errors.New("tag is not well-formed"),
+			expectedErr: errors.New("tag is not well-formed"),
 		},
 	}
 
@@ -51,14 +51,17 @@ func Test_ParseUploadParams(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			parsed, err := parseUploadParams(tt.req)
+			parsed, err := parseUploadParams(tt.input)
 
-			if tt.wantErr != nil {
-				assert.ErrorContains(t, err, tt.wantErr.Error())
+			if tt.expectedErr != nil {
+				assert.ErrorContains(t, err, tt.expectedErr.Error())
 				return
 			}
 
-			assert.NoError(t, err)
+			if !assert.NoError(t, err) {
+				return
+			}
+
 			assert.NotEmpty(t, parsed)
 		})
 	}
@@ -68,35 +71,35 @@ func Test_ValidateUploadParams(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name    string
-		wantErr error
-		params  uploadParams
+		name        string
+		expectedErr error
+		input       uploadParams
 	}{
 		{
 			name: "Happy Path",
-			params: uploadParams{
+			input: uploadParams{
 				Language: language.MustParse("lv-LV"),
 				Data:     []byte(`{"key":"value"}`),
 				Schema:   pb.Schema_GO,
 			},
-			wantErr: nil,
+			expectedErr: nil,
 		},
 		{
 			name: "Empty data",
-			params: uploadParams{
+			input: uploadParams{
 				Language: language.MustParse("lv-LV"),
 				Schema:   pb.Schema_GO,
 			},
-			wantErr: errors.New("'data' is required"),
+			expectedErr: errors.New("'data' is required"),
 		},
 		{
 			name: "Unspecified schema",
-			params: uploadParams{
+			input: uploadParams{
 				Language: language.MustParse("lv-LV"),
 				Data:     []byte(`{"key":"value"}`),
 				Schema:   pb.Schema_UNSPECIFIED,
 			},
-			wantErr: errors.New("'schema' is required"),
+			expectedErr: errors.New("'schema' is required"),
 		},
 	}
 	for _, tt := range tests {
@@ -104,10 +107,10 @@ func Test_ValidateUploadParams(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			err := tt.params.validate()
+			err := tt.input.validate()
 
-			if tt.wantErr != nil {
-				assert.ErrorContains(t, err, tt.wantErr.Error())
+			if tt.expectedErr != nil {
+				assert.ErrorContains(t, err, tt.expectedErr.Error())
 				return
 			}
 
@@ -120,33 +123,33 @@ func Test_ParseDownloadParams(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		req     *pb.DownloadTranslationFileRequest
-		wantErr error
-		name    string
+		input       *pb.DownloadTranslationFileRequest
+		expectedErr error
+		name        string
 	}{
 		{
 			name: "Happy Path",
-			req: &pb.DownloadTranslationFileRequest{
+			input: &pb.DownloadTranslationFileRequest{
 				Language: "lv-LV",
 				Schema:   pb.Schema_GO,
 			},
-			wantErr: nil,
+			expectedErr: nil,
 		},
 		{
 			name: "Malformed language tag",
-			req: &pb.DownloadTranslationFileRequest{
+			input: &pb.DownloadTranslationFileRequest{
 				Language: "xyz-ZY-Latn",
 				Schema:   pb.Schema_GO,
 			},
-			wantErr: errors.New("subtag \"xyz\" is well-formed but unknown"),
+			expectedErr: errors.New("subtag \"xyz\" is well-formed but unknown"),
 		},
 		{
 			name: "Missing language",
-			req: &pb.DownloadTranslationFileRequest{
+			input: &pb.DownloadTranslationFileRequest{
 				Language: "",
 				Schema:   pb.Schema_GO,
 			},
-			wantErr: errors.New("tag is not well-formed"),
+			expectedErr: errors.New("tag is not well-formed"),
 		},
 	}
 	for _, tt := range tests {
@@ -154,14 +157,17 @@ func Test_ParseDownloadParams(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			parsed, err := parseDownloadParams(tt.req)
+			parsed, err := parseDownloadParams(tt.input)
 
-			if tt.wantErr != nil {
-				assert.ErrorContains(t, err, tt.wantErr.Error())
+			if tt.expectedErr != nil {
+				assert.ErrorContains(t, err, tt.expectedErr.Error())
 				return
 			}
 
-			assert.NoError(t, err)
+			if !assert.NoError(t, err) {
+				return
+			}
+
 			assert.NotEmpty(t, parsed)
 		})
 	}


### PR DESCRIPTION
Small refactoring of tests, to remain consistent
Goal:
```go
tests := []struct {
	name        string   // Test name
        expected    ...      // Expected value from test
	expectedErr error    // Expected error or nil
	input       ...      // Test function's argument or arguments
}

...

for _, tt := range tests{
    actual := testFunc(tt.input)
    assert.Equal(t, tt.expected, actual)
}

```
