### PR TITLE
BUGFIX - +migrate | sh: missing ]]

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -61,7 +61,7 @@ migrate:
   WORKDIR /migrations
   COPY migrate/$db/* /migrations
   RUN --push --secret=db_password \
-    if [[ $db = "mysql"]]; then migrate -path=. -database "$db://$db_user:$db_password@tcp($db_host:$db_port)/$db_schema" $cmd; fi
+    if [[ $db = "mysql" ]]; then migrate -path=. -database "$db://$db_user:$db_password@tcp($db_host:$db_port)/$db_schema" $cmd; fi
 
 # -----------------------Linting-----------------------
 

--- a/Earthfile
+++ b/Earthfile
@@ -61,7 +61,7 @@ migrate:
   WORKDIR /migrations
   COPY migrate/$db/* /migrations
   RUN --push --secret=db_password \
-    if [[ $db = "mysql" ]]; then migrate -path=. -database "$db://$db_user:$db_password@tcp($db_host:$db_port)/$db_schema" $cmd; fi
+    if [[ $db = "mysql" ]]; then yes | migrate -path=. -database "$db://$db_user:$db_password@tcp($db_host:$db_port)/$db_schema" $cmd; fi
 
 # -----------------------Linting-----------------------
 


### PR DESCRIPTION
`earthly +migrate` fails with

```sh
            +migrate | --> RUN --push if [[ $db = "mysql"]]; then migrate -path=. -database "$db://$db_user:$db_password@tcp($db_host:$db_port)/$db_schema" $cmd; fi
            +migrate | sh: missing ]]
               +base | [----------] 100% sha256:139a4d6a7f082b9706952969f75879d315c8c6c03c7b7cccf96afdfb36e3619c
```