### PR TITLE
Change XLIFF 1.2 and XLIFF 2.0 Import Behaviour

### DIFF
--- a/pkg/convert/xliff12.go
+++ b/pkg/convert/xliff12.go
@@ -41,7 +41,7 @@ type transUnit struct {
 func FromXliff12(data []byte) (model.Messages, error) {
 	var xlf xliff12
 	if err := xml.Unmarshal(data, &xlf); err != nil {
-		return model.Messages{}, fmt.Errorf("unmarshal to xliff12: %w", err)
+		return model.Messages{}, fmt.Errorf("unmarshal xliff12: %w", err)
 	}
 
 	messages := model.Messages{
@@ -96,10 +96,8 @@ func ToXliff12(messages model.Messages) ([]byte, error) {
 
 	data, err := xml.Marshal(&xlf)
 	if err != nil {
-		return nil, fmt.Errorf("marshal xliff12 struct to XLIFF 1.2 formatted XML: %w", err)
+		return nil, fmt.Errorf("marshal xliff12: %w", err)
 	}
 
-	dataWithHeader := append([]byte(xml.Header), data...) // prepend generic XML header
-
-	return dataWithHeader, nil
+	return append([]byte(xml.Header), data...), nil
 }

--- a/pkg/convert/xliff12.go
+++ b/pkg/convert/xliff12.go
@@ -49,18 +49,12 @@ func FromXliff12(data []byte) (model.Messages, error) {
 		Messages: make([]model.Message, 0, len(xlf.File.Body.TransUnits)),
 	}
 
-	// Check if file has a target language set
-	isTranslated := xlf.File.TargetLanguage != language.Und
-	if isTranslated {
+	getMessage := func(t transUnit) string { return t.Source }
+
+	// Check if a target language is set
+	if xlf.File.TargetLanguage != language.Und {
 		messages.Language = xlf.File.TargetLanguage
-	}
-
-	getMessage := func(t transUnit) string {
-		if isTranslated {
-			return t.Target
-		}
-
-		return t.Source
+		getMessage = func(t transUnit) string { return t.Target }
 	}
 
 	for _, unit := range xlf.File.Body.TransUnits {

--- a/pkg/convert/xliff12_test.go
+++ b/pkg/convert/xliff12_test.go
@@ -2,91 +2,96 @@ package convert
 
 import (
 	"fmt"
+	"math/rand"
+	"reflect"
+	"strings"
 	"testing"
+	"testing/quick"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.expect.digital/translate/pkg/model"
-	"golang.org/x/text/language"
+	"go.expect.digital/translate/pkg/testutil"
+	testutilrand "go.expect.digital/translate/pkg/testutil/rand"
 )
+
+// randXliff12 dynamically generates a random XLIFF 1.2 file from the given messages.
+func randXliff12(target bool, messages *model.Messages) []byte {
+	sb := strings.Builder{}
+
+	sb.WriteString(`<?xml version="1.0" encoding="UTF-8"?>`)
+	sb.WriteString("<xliff xmlns=\"urn:oasis:names:tc:xliff:document:1.2\" version=\"1.2\">")
+
+	if target {
+		fmt.Fprintf(&sb, "<file source-language=\"und\" target-language=\"%s\">", messages.Language)
+	} else {
+		fmt.Fprintf(&sb, "<file source-language=\"%s\" target-language=\"und\">", messages.Language)
+	}
+
+	sb.WriteString("<body>")
+
+	for _, msg := range messages.Messages {
+		fmt.Fprintf(&sb, "<trans-unit id=\"%s\">", msg.ID)
+
+		if target {
+			fmt.Fprintf(&sb, "<target>%s</target>", msg.Message)
+		} else {
+			fmt.Fprintf(&sb, "<source>%s</source>", msg.Message)
+		}
+
+		if msg.Description != "" {
+			fmt.Fprintf(&sb, "<note>%s</note>", msg.Description)
+		}
+
+		sb.WriteString("</trans-unit>")
+	}
+
+	sb.WriteString("</body>")
+	sb.WriteString("</file>")
+	sb.WriteString("</xliff>")
+
+	return []byte(sb.String())
+}
 
 func Test_FromXliff12(t *testing.T) {
 	t.Parallel()
 
+	msgOpts := []testutilrand.ModelMessageOption{
+		testutilrand.WithFuzzy(false), // Do not mark message as fuzzy, as this is not supported by XLIFF 1.2
+	}
+
+	testMessages := testutilrand.ModelMessagesSlice(2, 5, msgOpts)
+
 	tests := []struct {
-		name        string
-		expectedErr error
-		input       []byte
-		expected    model.Messages
+		name     string
+		expected *model.Messages
+		input    []byte
 	}{
 		{
-			name: "All OK",
-			input: []byte(`<?xml version="1.0" encoding="UTF-8"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-  <file source-language="en" target-language="fr" datatype="plaintext" original="ng2.template">
-    <body>
-      <trans-unit id="introductionHeader" datatype="html">
-        <source>Hello!</source>
-        <note priority="1" from="description">An introduction header for this sample</note>
-      </trans-unit>
-      <trans-unit id="welcomeMessage" datatype="html">
-        <source>Welcome</source>
-      </trans-unit>
-    </body>
-  </file>
-</xliff>`),
-			expected: model.Messages{
-				Language: language.English,
-				Messages: []model.Message{
-					{
-						ID:          "introductionHeader",
-						Message:     "{Hello!}",
-						Description: "An introduction header for this sample",
-					},
-					{
-						ID:      "welcomeMessage",
-						Message: "{Welcome}",
-					},
-				},
-			},
-			expectedErr: nil,
+			name:     "Happy Path Untranslated",
+			input:    randXliff12(false, testMessages[0]),
+			expected: testMessages[0],
 		},
 		{
-			name: "Malformed language",
-			input: []byte(`<?xml version="1.0" encoding="UTF-8"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-  <file source-language="xyz-ZY-Latn" target-language="fr" datatype="plaintext" original="ng2.template">
-    <body>
-      <trans-unit id="introductionHeader" datatype="html">
-        <source>Hello!</source>
-        <note priority="1" from="developer">An introduction header for this sample</note>
-      </trans-unit>
-      <trans-unit id="welcomeMessage" datatype="html">
-        <source>Welcome</source>
-      </trans-unit>
-    </body>
-  </file>
-</xliff>`),
-			expectedErr: fmt.Errorf("language: subtag \"xyz\" is well-formed but unknown"),
+			name:     "Happy Path Translated",
+			input:    randXliff12(true, testMessages[1]),
+			expected: testMessages[1],
 		},
 	}
+
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
 			actual, err := FromXliff12(tt.input)
+			require.NoError(t, err)
 
-			if tt.expectedErr != nil {
-				assert.ErrorContains(t, err, tt.expectedErr.Error())
-				return
+			for i := range actual.Messages {
+				actual.Messages[i].Message = strings.Trim(actual.Messages[i].Message, "{}") // Remove curly braces for comparison
 			}
 
-			if !assert.NoError(t, err) {
-				return
-			}
-
-			assert.Equal(t, tt.expected.Language, actual.Language)
-			assert.ElementsMatch(t, tt.expected.Messages, actual.Messages)
+			testutil.EqualMessages(t, tt.expected, &actual)
 		})
 	}
 }
@@ -94,71 +99,49 @@ func Test_FromXliff12(t *testing.T) {
 func Test_ToXliff12(t *testing.T) {
 	t.Parallel()
 
-	tests := []struct {
-		name        string
-		expected    []byte
-		expectedErr error
-		input       model.Messages
-	}{
-		{
-			name: "All OK",
-			expected: []byte(`<?xml version="1.0" encoding="UTF-8"?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file source-language="en">
-    <body>
-      <trans-unit id="Welcome">
-        <source>Welcome to our website!</source>
-        <note>To welcome a new visitor</note>
-      </trans-unit>
-      <trans-unit id="Error">
-        <source>Something went wrong. Please try again later.</source>
-        <note>To inform the user of an error</note>
-      </trans-unit>
-      <trans-unit id="Feedback">
-        <source>We appreciate your feedback. Thank you for using our service.</source>
-      </trans-unit>
-    </body>
-  </file>
-</xliff>`),
-			expectedErr: nil,
-			input: model.Messages{
-				Language: language.English,
-				Messages: []model.Message{
-					{
-						ID:          "Welcome",
-						Message:     "{Welcome to our website!}",
-						Description: "To welcome a new visitor",
-					},
-					{
-						ID:          "Error",
-						Message:     "{Something went wrong. Please try again later.}",
-						Description: "To inform the user of an error",
-					},
-					{
-						ID:      "Feedback",
-						Message: "{We appreciate your feedback. Thank you for using our service.}",
-					},
-				},
+	msgOpts := []testutilrand.ModelMessageOption{
+		testutilrand.WithFuzzy(false), // Do not mark message as fuzzy, as this is not supported by XLIFF 1.2
+	}
+
+	messages := testutilrand.ModelMessages(4, msgOpts)
+	expected := randXliff12(false, messages)
+
+	actual, err := ToXliff12(*messages)
+	require.NoError(t, err)
+
+	assertEqualXml(t, expected, actual)
+}
+
+func Test_TransformXLIFF12(t *testing.T) {
+	t.Parallel()
+
+	t.Run("All OK", func(t *testing.T) {
+		t.Parallel()
+
+		msgOpts := []testutilrand.ModelMessageOption{
+			testutilrand.WithMessageFormat(), // Enclose message in curly braces
+			testutilrand.WithFuzzy(false),    // Do not mark message as fuzzy, as this is not supported by XLIFF 1.2
+		}
+
+		conf := &quick.Config{
+			MaxCount: 1000,
+			Values: func(values []reflect.Value, _ *rand.Rand) {
+				values[0] = reflect.ValueOf(testutilrand.ModelMessages(3, msgOpts)) // input generator
 			},
-		},
-	}
-	for _, tt := range tests {
-		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
+		}
 
-			actual, err := ToXliff12(tt.input)
+		f := func(expected *model.Messages) bool {
+			xliffData, err := ToXliff12(*expected)
+			require.NoError(t, err)
 
-			if tt.expectedErr != nil {
-				assert.ErrorContains(t, err, tt.expectedErr.Error())
-				return
-			}
+			restoredMessages, err := FromXliff12(xliffData)
+			require.NoError(t, err)
 
-			if !assert.NoError(t, err) {
-				return
-			}
+			testutil.EqualMessages(t, expected, &restoredMessages)
 
-			assertEqualXml(t, tt.expected, actual)
-		})
-	}
+			return true
+		}
+
+		assert.NoError(t, quick.Check(f, conf))
+	})
 }

--- a/pkg/convert/xliff12_test.go
+++ b/pkg/convert/xliff12_test.go
@@ -116,12 +116,13 @@ func Test_TransformXLIFF12(t *testing.T) {
 	t.Parallel()
 
 	msgOpts := []testutilrand.ModelMessageOption{
-		testutilrand.WithMessageFormat(), // Enclose message in curly braces
-		testutilrand.WithFuzzy(false),    // Do not mark message as fuzzy, as this is not supported by XLIFF 1.2
+		// Enclose message in curly braces, as ToXliff12() removes them, and FromXliff12() adds them again
+		testutilrand.WithMessageFormat(),
+		testutilrand.WithFuzzy(false), // Do not mark message as fuzzy, as this is not supported by XLIFF 1.2
 	}
 
 	conf := &quick.Config{
-		MaxCount: 1000,
+		MaxCount: 100,
 		Values: func(values []reflect.Value, _ *rand.Rand) {
 			values[0] = reflect.ValueOf(testutilrand.ModelMessages(3, msgOpts)) // input generator
 		},

--- a/pkg/convert/xliff2.go
+++ b/pkg/convert/xliff2.go
@@ -49,18 +49,12 @@ func FromXliff2(data []byte) (model.Messages, error) {
 		Messages: make([]model.Message, 0, len(xlf.File.Units)),
 	}
 
-	// Check if file has a target language set
-	isTranslated := xlf.TrgLang != language.Und
-	if isTranslated {
+	getMessage := func(u unit) string { return u.Source }
+
+	// Check if a target language is set
+	if xlf.TrgLang != language.Und {
 		messages.Language = xlf.TrgLang
-	}
-
-	getMessage := func(u unit) string {
-		if isTranslated {
-			return u.Target
-		}
-
-		return u.Source
+		getMessage = func(u unit) string { return u.Target }
 	}
 
 	findDescription := func(u unit) string {

--- a/pkg/convert/xliff2.go
+++ b/pkg/convert/xliff2.go
@@ -8,6 +8,8 @@ import (
 	"golang.org/x/text/language"
 )
 
+// TODO: For now we can only import XLIFF 2.0 files, export is not working correctly yet.
+
 // XLIFF 2 Specification: https://docs.oasis-open.org/xliff/xliff-core/v2.0/os/xliff-core-v2.0-os.html
 // XLIFF 2 Example: https://localizely.com/xliff-file/?tab=xliff-20
 
@@ -15,6 +17,7 @@ type xliff2 struct {
 	XMLName xml.Name     `xml:"urn:oasis:names:tc:xliff:document:2.0 xliff"`
 	Version string       `xml:"version,attr"`
 	SrcLang language.Tag `xml:"srcLang,attr"`
+	TrgLang language.Tag `xml:"trgLang,attr"`
 	File    xliff2File   `xml:"file"`
 }
 type xliff2File struct {
@@ -22,24 +25,43 @@ type xliff2File struct {
 }
 
 type unit struct {
-	ID     string  `xml:"id,attr"`
-	Notes  *[]note `xml:"notes>note"` // Set as pointer to avoid empty <notes></notes> when marshalling.
-	Source string  `xml:"segment>source"`
+	ID     string  `xml:"id,attr"`                  // messages.messages[n].ID
+	Notes  *[]note `xml:"notes>note"`               // Set as pointer to avoid empty <notes></notes> when marshalling.
+	Source string  `xml:"segment>source"`           // messages.messages[n].Message (if no target language is set)
+	Target string  `xml:"segment>target,omitempty"` // messages.messages[n].Message (if target language is set)
+	// No unified standard about storing fuzzy values
 }
 
 type note struct {
 	Category string `xml:"category,attr"`
-	Content  string `xml:",chardata"`
+	Content  string `xml:",chardata"` // messages.messages[n].Description (if Category == "description")
 }
 
 // FromXliff2 converts serialized data from the XML data in the XLIFF 2 format into a model.Messages struct.
 func FromXliff2(data []byte) (model.Messages, error) {
 	var xlf xliff2
 	if err := xml.Unmarshal(data, &xlf); err != nil {
-		return model.Messages{}, fmt.Errorf("unmarshal XLIFF 2 formatted XML into xliff2 struct: %w", err)
+		return model.Messages{}, fmt.Errorf("unmarshal xliff2: %w", err)
 	}
 
-	messages := model.Messages{Language: xlf.SrcLang, Messages: make([]model.Message, 0, len(xlf.File.Units))}
+	messages := model.Messages{
+		Language: xlf.SrcLang,
+		Messages: make([]model.Message, 0, len(xlf.File.Units)),
+	}
+
+	// Check if file has a target language set
+	isTranslated := xlf.TrgLang != language.Und
+	if isTranslated {
+		messages.Language = xlf.TrgLang
+	}
+
+	getMessage := func(u unit) string {
+		if isTranslated {
+			return u.Target
+		}
+
+		return u.Source
+	}
 
 	findDescription := func(u unit) string {
 		for _, note := range *u.Notes {
@@ -54,7 +76,7 @@ func FromXliff2(data []byte) (model.Messages, error) {
 	for _, unit := range xlf.File.Units {
 		messages.Messages = append(messages.Messages, model.Message{
 			ID:          unit.ID,
-			Message:     convertToMessageFormatSingular(unit.Source),
+			Message:     convertToMessageFormatSingular(getMessage(unit)),
 			Description: findDescription(unit),
 		})
 	}
@@ -87,10 +109,8 @@ func ToXliff2(messages model.Messages) ([]byte, error) {
 
 	data, err := xml.Marshal(&xlf)
 	if err != nil {
-		return nil, fmt.Errorf("marshal xliff2 struct to XLIFF 2 formatted XML: %w", err)
+		return nil, fmt.Errorf("marshal xliff2: %w", err)
 	}
 
-	dataWithHeader := append([]byte(xml.Header), data...) // prepend generic XML header
-
-	return dataWithHeader, nil
+	return append([]byte(xml.Header), data...), nil
 }

--- a/pkg/convert/xliff2_test.go
+++ b/pkg/convert/xliff2_test.go
@@ -129,33 +129,29 @@ func Test_ToXliff2(t *testing.T) {
 func Test_TransformXLIFF2(t *testing.T) {
 	t.Parallel()
 
-	t.Run("All OK", func(t *testing.T) {
-		t.Parallel()
+	msgOpts := []testutilrand.ModelMessageOption{
+		testutilrand.WithMessageFormat(), // Enclose message in curly braces
+		testutilrand.WithFuzzy(false),    // Do not mark message as fuzzy, as this is not supported by XLIFF 1.2
+	}
 
-		msgOpts := []testutilrand.ModelMessageOption{
-			testutilrand.WithMessageFormat(), // Enclose message in curly braces
-			testutilrand.WithFuzzy(false),    // Do not mark message as fuzzy, as this is not supported by XLIFF 1.2
-		}
+	conf := &quick.Config{
+		MaxCount: 1000,
+		Values: func(values []reflect.Value, _ *rand.Rand) {
+			values[0] = reflect.ValueOf(testutilrand.ModelMessages(3, msgOpts)) // input generator
+		},
+	}
 
-		conf := &quick.Config{
-			MaxCount: 1000,
-			Values: func(values []reflect.Value, _ *rand.Rand) {
-				values[0] = reflect.ValueOf(testutilrand.ModelMessages(3, msgOpts)) // input generator
-			},
-		}
+	f := func(expected *model.Messages) bool {
+		xliffData, err := ToXliff2(*expected)
+		require.NoError(t, err)
 
-		f := func(expected *model.Messages) bool {
-			xliffData, err := ToXliff2(*expected)
-			require.NoError(t, err)
+		restoredMessages, err := FromXliff2(xliffData)
+		require.NoError(t, err)
 
-			restoredMessages, err := FromXliff2(xliffData)
-			require.NoError(t, err)
+		testutil.EqualMessages(t, expected, &restoredMessages)
 
-			testutil.EqualMessages(t, expected, &restoredMessages)
+		return true
+	}
 
-			return true
-		}
-
-		assert.NoError(t, quick.Check(f, conf))
-	})
+	assert.NoError(t, quick.Check(f, conf))
 }

--- a/pkg/convert/xliff2_test.go
+++ b/pkg/convert/xliff2_test.go
@@ -130,12 +130,13 @@ func Test_TransformXLIFF2(t *testing.T) {
 	t.Parallel()
 
 	msgOpts := []testutilrand.ModelMessageOption{
-		testutilrand.WithMessageFormat(), // Enclose message in curly braces
-		testutilrand.WithFuzzy(false),    // Do not mark message as fuzzy, as this is not supported by XLIFF 1.2
+		// Enclose message in curly braces, as ToXliff2() removes them, and FromXliff2() adds them again
+		testutilrand.WithMessageFormat(),
+		testutilrand.WithFuzzy(false), // Do not mark message as fuzzy, as this is not supported by XLIFF 1.2
 	}
 
 	conf := &quick.Config{
-		MaxCount: 1000,
+		MaxCount: 100,
 		Values: func(values []reflect.Value, _ *rand.Rand) {
 			values[0] = reflect.ValueOf(testutilrand.ModelMessages(3, msgOpts)) // input generator
 		},

--- a/pkg/convert/xliff2_test.go
+++ b/pkg/convert/xliff2_test.go
@@ -2,13 +2,60 @@ package convert
 
 import (
 	"fmt"
+	"math/rand"
+	"reflect"
 	"regexp"
+	"strings"
 	"testing"
+	"testing/quick"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.expect.digital/translate/pkg/model"
-	"golang.org/x/text/language"
+	"go.expect.digital/translate/pkg/testutil"
+	testutilrand "go.expect.digital/translate/pkg/testutil/rand"
 )
+
+func randXliff2(target bool, messages *model.Messages) []byte {
+	sb := strings.Builder{}
+
+	sb.WriteString(`<?xml version="1.0" encoding="UTF-8"?>`)
+
+	if target {
+		fmt.Fprintf(
+			&sb,
+			"<xliff xmlns=\"urn:oasis:names:tc:xliff:document:2.0\" version=\"2.0\" srcLang=\"und\" trgLang=\"%s\">",
+			messages.Language)
+	} else {
+		fmt.Fprintf(
+			&sb,
+			"<xliff xmlns=\"urn:oasis:names:tc:xliff:document:2.0\" version=\"2.0\" srcLang=\"%s\" trgLang=\"und\">",
+			messages.Language)
+	}
+
+	sb.WriteString("<file>")
+
+	for _, msg := range messages.Messages {
+		fmt.Fprintf(&sb, "<unit id=\"%s\">", msg.ID)
+
+		if msg.Description != "" {
+			fmt.Fprintf(&sb, "<notes><note category=\"description\">%s</note></notes>", msg.Description)
+		}
+
+		if target {
+			fmt.Fprintf(&sb, "<segment><target>%s</target></segment>", msg.Message)
+		} else {
+			fmt.Fprintf(&sb, "<segment><source>%s</source></segment>", msg.Message)
+		}
+
+		sb.WriteString("</unit>")
+	}
+
+	sb.WriteString("</file>")
+	sb.WriteString("</xliff>")
+
+	return []byte(sb.String())
+}
 
 func assertEqualXml(t *testing.T, expected, actual []byte) bool { //nolint:unparam
 	t.Helper()
@@ -20,103 +67,45 @@ func assertEqualXml(t *testing.T, expected, actual []byte) bool { //nolint:unpar
 	return assert.Equal(t, expectedTrimmed, actualTrimmed)
 }
 
-func TestFromXliff2(t *testing.T) {
+func Test_FromXliff2(t *testing.T) {
 	t.Parallel()
 
+	msgOpts := []testutilrand.ModelMessageOption{
+		testutilrand.WithFuzzy(false), // Do not mark message as fuzzy, as this is not supported by XLIFF 2.0
+	}
+
+	testMessages := testutilrand.ModelMessagesSlice(2, 5, msgOpts)
+
 	tests := []struct {
-		name        string
-		expectedErr error
-		input       []byte
-		expected    model.Messages
+		name     string
+		expected *model.Messages
+		input    []byte
 	}{
 		{
-			name: "All OK",
-			input: []byte(`<?xml version="1.0" encoding="UTF-8"?>
-<xliff version="2.0" xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en" trgLang="fr">
-  <file id="ngi18n" original="ng.template">
-    <unit id="common.welcome">
-      <notes>
-        <note category="location">src/app/app.component.html:16</note>
-      </notes>
-      <segment>
-        <source>Welcome!</source>
-        <target>Bienvenue!</target>
-      </segment>
-    </unit>
-    <unit id="common.app.title">
-      <notes>
-        <note category="location">src/app/app.component.html:4</note>
-        <note category="description">App title</note>
-      </notes>
-      <segment>
-        <source>Diary</source>
-        <target>Agenda</target>
-      </segment>
-    </unit>
-  </file>
-</xliff>`),
-			expected: model.Messages{
-				Language: language.English,
-				Messages: []model.Message{
-					{
-						ID:      "common.welcome",
-						Message: "{Welcome!}",
-					},
-					{
-						ID:          "common.app.title",
-						Message:     "{Diary}",
-						Description: "App title",
-					},
-				},
-			},
-			expectedErr: nil,
+			name:     "Happy Path Untranslated",
+			input:    randXliff2(false, testMessages[0]),
+			expected: testMessages[0],
 		},
 		{
-			name: "Malformed language",
-			input: []byte(`<?xml version="1.0" encoding="UTF-8"?>
-<xliff version="2.0" xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="xyz-ZY-Latn" trgLang="fr">
-  <file id="ngi18n" original="ng.template">
-    <unit id="common.welcome">
-      <notes>
-        <note category="location">src/app/app.component.html:16</note>
-      </notes>
-      <segment>
-        <source>Welcome!</source>
-        <target>Bienvenue!</target>
-      </segment>
-    </unit>
-    <unit id="common.app.title">
-      <notes>
-        <note category="location">src/app/app.component.html:4</note>
-        <note category="description">App title</note>
-      </notes>
-      <segment>
-        <source>Diary</source>
-        <target>Agenda</target>
-      </segment>
-    </unit>
-  </file>
-</xliff>`),
-			expectedErr: fmt.Errorf("language: subtag \"xyz\" is well-formed but unknown"),
+			name:     "Happy Path Translated",
+			input:    randXliff2(true, testMessages[1]),
+			expected: testMessages[1],
 		},
 	}
+
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
 			actual, err := FromXliff2(tt.input)
-			if tt.expectedErr != nil {
-				assert.ErrorContains(t, err, tt.expectedErr.Error())
-				return
+			require.NoError(t, err)
+
+			for i := range actual.Messages {
+				actual.Messages[i].Message = strings.Trim(actual.Messages[i].Message, "{}") // Remove curly braces for comparison
 			}
 
-			if !assert.NoError(t, err) {
-				return
-			}
-
-			assert.Equal(t, tt.expected.Language, actual.Language)
-			assert.ElementsMatch(t, tt.expected.Messages, actual.Messages)
+			testutil.EqualMessages(t, tt.expected, &actual)
 		})
 	}
 }
@@ -124,79 +113,49 @@ func TestFromXliff2(t *testing.T) {
 func Test_ToXliff2(t *testing.T) {
 	t.Parallel()
 
-	tests := []struct {
-		name        string
-		expected    []byte
-		expectedErr error
-		input       model.Messages
-	}{
-		{
-			name: "All OK",
-			expected: []byte(`<?xml version="1.0" encoding="UTF-8"?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="en">
-  <file>
-    <unit id="Welcome">
-      <notes>
-        <note category="description">To welcome a new visitor</note>
-      </notes>
-      <segment>
-        <source>Welcome to our website!</source>
-      </segment>
-    </unit>
-    <unit id="Error">
-      <notes>
-        <note category="description">To inform the user of an error</note>
-      </notes>
-      <segment>
-        <source>Something went wrong. Please try again later.</source>
-      </segment>
-    </unit>
-    <unit id="Feedback">
-      <segment>
-        <source>We appreciate your feedback. Thank you for using our service.</source>
-      </segment>
-    </unit>
-  </file>
-</xliff>`),
-			expectedErr: nil,
-			input: model.Messages{
-				Language: language.English,
-				Messages: []model.Message{
-					{
-						ID:          "Welcome",
-						Message:     "{Welcome to our website!}",
-						Description: "To welcome a new visitor",
-					},
-					{
-						ID:          "Error",
-						Message:     "{Something went wrong. Please try again later.}",
-						Description: "To inform the user of an error",
-					},
-					{
-						ID:      "Feedback",
-						Message: "{We appreciate your feedback. Thank you for using our service.}",
-					},
-				},
+	msgOpts := []testutilrand.ModelMessageOption{
+		testutilrand.WithFuzzy(false), // Do not mark message as fuzzy, as this is not supported by XLIFF 2.0
+	}
+
+	messages := testutilrand.ModelMessages(4, msgOpts)
+	expected := randXliff2(false, messages)
+
+	actual, err := ToXliff2(*messages)
+	require.NoError(t, err)
+
+	assertEqualXml(t, expected, actual)
+}
+
+func Test_TransformXLIFF2(t *testing.T) {
+	t.Parallel()
+
+	t.Run("All OK", func(t *testing.T) {
+		t.Parallel()
+
+		msgOpts := []testutilrand.ModelMessageOption{
+			testutilrand.WithMessageFormat(), // Enclose message in curly braces
+			testutilrand.WithFuzzy(false),    // Do not mark message as fuzzy, as this is not supported by XLIFF 1.2
+		}
+
+		conf := &quick.Config{
+			MaxCount: 1000,
+			Values: func(values []reflect.Value, _ *rand.Rand) {
+				values[0] = reflect.ValueOf(testutilrand.ModelMessages(3, msgOpts)) // input generator
 			},
-		},
-	}
-	for _, tt := range tests {
-		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
+		}
 
-			actual, err := ToXliff2(tt.input)
+		f := func(expected *model.Messages) bool {
+			xliffData, err := ToXliff2(*expected)
+			require.NoError(t, err)
 
-			if tt.expectedErr != nil {
-				assert.ErrorContains(t, err, tt.expectedErr.Error())
-				return
-			}
+			restoredMessages, err := FromXliff2(xliffData)
+			require.NoError(t, err)
 
-			if !assert.NoError(t, err) {
-				return
-			}
+			testutil.EqualMessages(t, expected, &restoredMessages)
 
-			assertEqualXml(t, tt.expected, actual)
-		})
-	}
+			return true
+		}
+
+		assert.NoError(t, quick.Check(f, conf))
+	})
 }

--- a/pkg/testutil/compare.go
+++ b/pkg/testutil/compare.go
@@ -12,6 +12,6 @@ func EqualMessages(t *testing.T, expected, actual *model.Messages) {
 		require.Equal(t, expected, actual)
 	}
 
-	require.Equal(t, expected.Language, actual.Language)
+	require.Equal(t, expected.Language, actual.Language, "got language %s, want %s", actual.Language, expected.Language)
 	require.ElementsMatch(t, expected.Messages, actual.Messages)
 }

--- a/pkg/testutil/rand/model.go
+++ b/pkg/testutil/rand/model.go
@@ -111,6 +111,7 @@ func WithFuzzy(fuzzy bool) ModelMessageOption {
 	}
 }
 
+// WithMessageFormat encloses the message in curly braces.
 func WithMessageFormat() ModelMessageOption {
 	return func(m *model.Message) {
 		m.Message = "{" + m.Message + "}"

--- a/pkg/testutil/rand/model.go
+++ b/pkg/testutil/rand/model.go
@@ -111,6 +111,12 @@ func WithFuzzy(fuzzy bool) ModelMessageOption {
 	}
 }
 
+func WithMessageFormat() ModelMessageOption {
+	return func(m *model.Message) {
+		m.Message = "{" + m.Message + "}"
+	}
+}
+
 // ------------------Messages------------------
 
 // modelMessages generates a random model.Messages with the given


### PR DESCRIPTION
## Changes

Now imported messages are determined by the attribute of the source/target language
- if target language **is not** present, then messages are extracted from `<source>` element, and `messages` language is source-language
- if target language **is** present, then messages are extracted from `<target>` element, and `messages` language is target-language

## Test changes
- Refactored tests to include less boilerplate - now `XML's` are generated dynamically from provided random messages
- Added transform tests: messages->XLIFF->messages (Property-based testing)