### PR TITLE
Repo closer

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -36,7 +36,7 @@ init:
     echo "TRANSLATE_DB_MYSQL_DATABASE=translate" >> .env.test && \
     echo "" >> .env.test && \
     echo "# BadgerDB" >> .env.test && \
-    echo "TRANSLATE_DB_BADGERDB_PATH=${TMPDIR%/}/badgerdb" >> .env.test && \
+    echo "TRANSLATE_DB_BADGERDB_PATH=" >> .env.test && \
     echo "" >> .env.test && \
     echo "# Google Translate API" >> .env.test && \
     echo "TRANSLATE_OTHER_GOOGLE_PROJECT_ID=expect-digital" >> .env.test && \
@@ -53,7 +53,7 @@ init:
     echo "db_port=3306" >> .arg && \
     echo "db_user=root" >> .arg && \
     echo "db_schema=translate" >> .arg
-  RUN echo "db_password=" > .secret
+  RUN echo "db_password=" >> .secret
 
 up:
   LOCALLY

--- a/cmd/translate/service/service.go
+++ b/cmd/translate/service/service.go
@@ -79,8 +79,8 @@ var rootCmd = &cobra.Command{
 		}
 
 		defer func() {
-			if repoCloseErr := repo.Close(); repoCloseErr != nil {
-				log.Printf("close repo: %v", repoCloseErr)
+			if closeErr := repo.Close(); closeErr != nil {
+				log.Printf("close repo: %v", closeErr)
 			}
 		}()
 

--- a/cmd/translate/service/service.go
+++ b/cmd/translate/service/service.go
@@ -78,6 +78,12 @@ var rootCmd = &cobra.Command{
 			log.Panicf("create new repo: %v", err)
 		}
 
+		defer func() {
+			if repoCloseErr := repo.Close(); repoCloseErr != nil {
+				log.Printf("close repo: %v", repoCloseErr)
+			}
+		}()
+
 		var translator fuzzy.Translator
 
 		switch viper.GetString("service.translator") {

--- a/pkg/repo/badgerdb/repo.go
+++ b/pkg/repo/badgerdb/repo.go
@@ -13,6 +13,15 @@ type Repo struct {
 	db *badger.DB
 }
 
+func (r *Repo) Close() error {
+	err := r.db.Close()
+	if err != nil {
+		return fmt.Errorf("close badger db: %w", err)
+	}
+
+	return nil
+}
+
 type option func(*Repo) error
 
 // WithDefaultDB opens a new Badger database in file system

--- a/pkg/repo/factory/factory_integration_test.go
+++ b/pkg/repo/factory/factory_integration_test.go
@@ -45,6 +45,10 @@ func initBadgerDB() error {
 }
 
 func TestMain(m *testing.M) {
+	os.Exit(testMain(m))
+}
+
+func testMain(m *testing.M) int {
 	ctx := context.Background()
 
 	viper.SetEnvPrefix("translate")
@@ -67,7 +71,12 @@ func TestMain(m *testing.M) {
 		os.Exit(1)
 	}
 
-	os.Exit(m.Run())
+	// Close all connections
+	for _, repo := range repos {
+		defer repo.Close()
+	}
+
+	return m.Run()
 }
 
 // allRepos runs a test for each repo that is defined in the repos map.

--- a/pkg/repo/mysql/repo.go
+++ b/pkg/repo/mysql/repo.go
@@ -12,6 +12,15 @@ type Repo struct {
 	db *sql.DB
 }
 
+func (r *Repo) Close() error {
+	err := r.db.Close()
+	if err != nil {
+		return fmt.Errorf("close mysql db: %w", err)
+	}
+
+	return nil
+}
+
 // Option interface used for setting optional Repo properties.
 type Option interface {
 	apply(*Repo) error

--- a/pkg/repo/repo.go
+++ b/pkg/repo/repo.go
@@ -3,6 +3,7 @@ package repo
 import (
 	"context"
 	"errors"
+	"io"
 
 	"github.com/google/uuid"
 	"go.expect.digital/translate/pkg/model"
@@ -33,5 +34,5 @@ type Repo interface {
 	ServicesRepo
 	MessagesRepo
 
-	Close() error
+	io.Closer
 }

--- a/pkg/repo/repo.go
+++ b/pkg/repo/repo.go
@@ -32,4 +32,6 @@ type MessagesRepo interface {
 type Repo interface {
 	ServicesRepo
 	MessagesRepo
+
+	Close() error
 }


### PR DESCRIPTION
Apparently, the problem was not the not closing DB...

When running tests locally, instead of earthly, `cmd/client` and `cmd/service,` tries to acquire a lock on the `TRANSLATE_DB_BADGERDB_PATH` at the same time. On earthly this env variable is empty, which leads to use in memory storage.

Decided to leave `TRANSLATE_DB_BADGERDB_PATH` empty for tests, as it should suffice.  For running the service and trying to upload big files e.g. `Superset`, one should change this env some dir. 

Also left Close function, at least in badgerDB as it is crucial. 
