### PR TITLE
ignore no identifiers in predeclared lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -62,3 +62,5 @@ linters-settings:
     alias:
       - pkg: go.expect.digital/translate/pkg/pb/translate/v1
         alias: translatev1
+  predeclared:
+    ignore: ""


### PR DESCRIPTION
`golangci-lint` configures `predeclared` to ignore `new` and `int` by default.

**Ignore none.**