### PR TITLE
Parallelise CLI Tests

### DIFF
--- a/cmd/client/client_integration_test.go
+++ b/cmd/client/client_integration_test.go
@@ -38,7 +38,6 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	ctx := context.Background()
 	port := mustGetFreePort()
 	addr = fmt.Sprintf("%s:%s", host, port)
 
@@ -60,12 +59,12 @@ func TestMain(m *testing.M) {
 		grpc.WithBlock(),
 	}
 	// Wait for the server to start and establish a connection.
-	conn, err := grpc.DialContext(ctx, host+":"+port, grpcOpts...)
+	clientConn, err := grpc.DialContext(context.Background(), host+":"+port, grpcOpts...)
 	if err != nil {
 		log.Panicf("create connection to gRPC server: %v", err)
 	}
 
-	client = translatev1.NewTranslateServiceClient(conn)
+	client = translatev1.NewTranslateServiceClient(clientConn)
 
 	// Run the tests.
 	code := m.Run()
@@ -78,7 +77,7 @@ func TestMain(m *testing.M) {
 	wg.Wait()
 
 	// Close the connection and tracer.
-	if err := conn.Close(); err != nil {
+	if err := clientConn.Close(); err != nil {
 		log.Panicf("close gRPC client connection: %v", err)
 	}
 

--- a/cmd/client/client_integration_test.go
+++ b/cmd/client/client_integration_test.go
@@ -1,6 +1,5 @@
 //go:build integration
 
-//nolint:paralleltest
 package main
 
 import (
@@ -104,7 +103,10 @@ func mustGetFreePort() string {
 }
 
 func Test_ListServices_CLI(t *testing.T) {
+	t.Parallel()
+
 	t.Run("OK", func(t *testing.T) {
+		t.Parallel()
 		ctx, _ := testutil.Trace(t)
 
 		res, err := cmd.ExecuteWithParams(ctx, []string{
@@ -118,6 +120,7 @@ func Test_ListServices_CLI(t *testing.T) {
 	})
 
 	t.Run("error, no transport security set", func(t *testing.T) {
+		t.Parallel()
 		ctx, _ := testutil.Trace(t)
 
 		res, err := cmd.ExecuteWithParams(ctx, []string{
@@ -131,7 +134,10 @@ func Test_ListServices_CLI(t *testing.T) {
 }
 
 func Test_TranslationFileUpload_CLI(t *testing.T) {
+	t.Parallel()
+
 	t.Run("OK, file from local path", func(t *testing.T) {
+		t.Parallel()
 		ctx, _ := testutil.Trace(t)
 
 		service := createService(ctx, t)
@@ -161,6 +167,7 @@ func Test_TranslationFileUpload_CLI(t *testing.T) {
 	})
 
 	t.Run("OK, with local file and original flag", func(t *testing.T) {
+		t.Parallel()
 		ctx, _ := testutil.Trace(t)
 
 		service := createService(ctx, t)
@@ -191,6 +198,7 @@ func Test_TranslationFileUpload_CLI(t *testing.T) {
 	})
 
 	t.Run("OK, with local file, original=true populate=false", func(t *testing.T) {
+		t.Parallel()
 		ctx, _ := testutil.Trace(t)
 
 		service := createService(ctx, t)
@@ -222,6 +230,7 @@ func Test_TranslationFileUpload_CLI(t *testing.T) {
 	})
 
 	t.Run("OK, file from URL", func(t *testing.T) {
+		t.Parallel()
 		ctx, _ := testutil.Trace(t)
 
 		service := createService(ctx, t)
@@ -272,6 +281,7 @@ func Test_TranslationFileUpload_CLI(t *testing.T) {
 
 	// Translation has language tag, but CLI parameter 'language' is not set.
 	t.Run("OK, local without lang parameter", func(t *testing.T) {
+		t.Parallel()
 		ctx, _ := testutil.Trace(t)
 
 		service := createService(ctx, t)
@@ -301,6 +311,7 @@ func Test_TranslationFileUpload_CLI(t *testing.T) {
 	})
 
 	t.Run("error, malformed language", func(t *testing.T) {
+		t.Parallel()
 		ctx, _ := testutil.Trace(t)
 
 		file, err := os.CreateTemp(t.TempDir(), "test")
@@ -334,6 +345,7 @@ func Test_TranslationFileUpload_CLI(t *testing.T) {
 	})
 
 	t.Run("error, path parameter 'schema' unrecognized", func(t *testing.T) {
+		t.Parallel()
 		ctx, _ := testutil.Trace(t)
 
 		res, err := cmd.ExecuteWithParams(ctx, []string{
@@ -353,6 +365,7 @@ func Test_TranslationFileUpload_CLI(t *testing.T) {
 	})
 
 	t.Run("error, path parameter 'schema' unspecified", func(t *testing.T) {
+		t.Parallel()
 		ctx, _ := testutil.Trace(t)
 
 		res, err := cmd.ExecuteWithParams(ctx, []string{
@@ -372,6 +385,7 @@ func Test_TranslationFileUpload_CLI(t *testing.T) {
 	})
 
 	t.Run("error, path parameter 'schema' missing", func(t *testing.T) {
+		t.Parallel()
 		ctx, _ := testutil.Trace(t)
 
 		res, err := cmd.ExecuteWithParams(ctx, []string{
@@ -390,6 +404,7 @@ func Test_TranslationFileUpload_CLI(t *testing.T) {
 
 	// Translation does not have language tag, and CLI parameter 'language' is not set.
 	t.Run("error, language could not be determined", func(t *testing.T) {
+		t.Parallel()
 		ctx, _ := testutil.Trace(t)
 
 		service := createService(ctx, t)
@@ -419,6 +434,7 @@ func Test_TranslationFileUpload_CLI(t *testing.T) {
 	})
 
 	t.Run("error, path parameter 'path' missing", func(t *testing.T) {
+		t.Parallel()
 		ctx, _ := testutil.Trace(t)
 
 		res, err := cmd.ExecuteWithParams(ctx, []string{
@@ -436,6 +452,7 @@ func Test_TranslationFileUpload_CLI(t *testing.T) {
 	})
 
 	t.Run("error, path parameter 'service' missing", func(t *testing.T) {
+		t.Parallel()
 		ctx, _ := testutil.Trace(t)
 
 		res, err := cmd.ExecuteWithParams(ctx, []string{
@@ -454,7 +471,10 @@ func Test_TranslationFileUpload_CLI(t *testing.T) {
 }
 
 func Test_TranslationFileDownload_CLI(t *testing.T) {
+	t.Parallel()
+
 	t.Run("OK", func(t *testing.T) {
+		t.Parallel()
 		ctx, _ := testutil.Trace(t)
 
 		service := createService(ctx, t)
@@ -503,6 +523,7 @@ func Test_TranslationFileDownload_CLI(t *testing.T) {
 	})
 
 	t.Run("error, path parameter 'language' missing", func(t *testing.T) {
+		t.Parallel()
 		ctx, _ := testutil.Trace(t)
 
 		res, err := cmd.ExecuteWithParams(ctx, []string{
@@ -520,6 +541,7 @@ func Test_TranslationFileDownload_CLI(t *testing.T) {
 	})
 
 	t.Run("error, path parameter 'schema' missing", func(t *testing.T) {
+		t.Parallel()
 		ctx, _ := testutil.Trace(t)
 
 		res, err := cmd.ExecuteWithParams(ctx, []string{
@@ -537,6 +559,7 @@ func Test_TranslationFileDownload_CLI(t *testing.T) {
 	})
 
 	t.Run("error, path parameter 'service' missing", func(t *testing.T) {
+		t.Parallel()
 		ctx, _ := testutil.Trace(t)
 
 		res, err := cmd.ExecuteWithParams(ctx, []string{
@@ -554,6 +577,7 @@ func Test_TranslationFileDownload_CLI(t *testing.T) {
 	})
 
 	t.Run("error, path parameter 'path' missing", func(t *testing.T) {
+		t.Parallel()
 		ctx, _ := testutil.Trace(t)
 
 		res, err := cmd.ExecuteWithParams(ctx, []string{

--- a/cmd/client/client_integration_test.go
+++ b/cmd/client/client_integration_test.go
@@ -72,7 +72,7 @@ func testMain(m *testing.M) int {
 		log.Panicf("send termination signal: %v", err)
 	}
 
-	// Wait for main() to finish cleanup.
+	// Wait for grpc server to stop.
 	wg.Wait()
 
 	return code
@@ -86,14 +86,14 @@ func setUpClient() func() error {
 		grpc.WithBlock(),
 	}
 
-	clientConn, err := grpc.DialContext(context.Background(), host+":"+port, grpcOpts...)
+	conn, err := grpc.DialContext(context.Background(), host+":"+port, grpcOpts...)
 	if err != nil {
 		log.Panicf("create connection to gRPC server: %v", err)
 	}
 
-	client = translatev1.NewTranslateServiceClient(clientConn)
+	client = translatev1.NewTranslateServiceClient(conn)
 
-	return clientConn.Close
+	return conn.Close
 }
 
 func mustGetFreePort() string {

--- a/cmd/client/cmd/download.go
+++ b/cmd/client/cmd/download.go
@@ -9,7 +9,6 @@ import (
 	"path/filepath"
 
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 	translatev1 "go.expect.digital/translate/pkg/pb/translate/v1"
 )
 
@@ -84,7 +83,7 @@ func newDownloadCmd() *cobra.Command {
 				fileName += "." + xlf
 			}
 
-			if err = os.WriteFile(filepath.Join(path, fileName), res.GetData(), 0644); err != nil { //nolint:gomnd,gofumpt,gosec
+			if err = os.WriteFile(filepath.Join(path, fileName), res.GetData(), 0o644); err != nil { //nolint:gomnd,gosec
 				return fmt.Errorf("download file: write file to path: %w", err)
 			}
 
@@ -117,10 +116,6 @@ func newDownloadCmd() *cobra.Command {
 
 	if err := downloadCmd.MarkFlagRequired("schema"); err != nil {
 		log.Panicf("download file cmd: set field 'schema' as required: %v", err)
-	}
-
-	if err := viper.BindPFlags(downloadFlags); err != nil {
-		log.Panicf("download file cmd: bind flags: %v", err)
 	}
 
 	return downloadCmd

--- a/cmd/client/cmd/download.go
+++ b/cmd/client/cmd/download.go
@@ -35,11 +35,6 @@ func newDownloadCmd() *cobra.Command {
 			ctx, cancelFunc := context.WithTimeout(cmd.Context(), timeout)
 			defer cancelFunc()
 
-			client, err := newClientConn(ctx, cmd)
-			if err != nil {
-				return fmt.Errorf("download file: new GRPC client connection: %w", err)
-			}
-
 			serviceID, err := cmd.Flags().GetString("service")
 			if err != nil {
 				return fmt.Errorf("upload file: get cli parameter 'service': %w", err)
@@ -60,7 +55,7 @@ func newDownloadCmd() *cobra.Command {
 				return fmt.Errorf("download file: schema to translate schema: %w", err)
 			}
 
-			res, err := translatev1.NewTranslateServiceClient(client).DownloadTranslationFile(ctx,
+			res, err := translatev1.NewTranslateServiceClient(conn).DownloadTranslationFile(ctx,
 				&translatev1.DownloadTranslationFileRequest{
 					Language: language, Schema: translateSchema, ServiceId: serviceID,
 				})

--- a/cmd/client/cmd/list.go
+++ b/cmd/client/cmd/list.go
@@ -17,18 +17,13 @@ func newLsCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			timeout, err := cmd.InheritedFlags().GetDuration("timeout")
 			if err != nil {
-				return fmt.Errorf("list services: get cli parameter 'timeout': %w", err)
+				return fmt.Errorf("download file: get cli parameter 'timeout': %w", err)
 			}
 
 			ctx, cancelFunc := context.WithTimeout(cmd.Context(), timeout)
 			defer cancelFunc()
 
-			client, err := newClientConn(ctx, cmd)
-			if err != nil {
-				return fmt.Errorf("list services: new GRPC client connection: %w", err)
-			}
-
-			resp, err := translatev1.NewTranslateServiceClient(client).ListServices(ctx, &translatev1.ListServicesRequest{})
+			resp, err := translatev1.NewTranslateServiceClient(conn).ListServices(ctx, &translatev1.ListServicesRequest{})
 			if err != nil {
 				return fmt.Errorf("list services: send GRPC request: %w", err)
 			}

--- a/cmd/client/cmd/list.go
+++ b/cmd/client/cmd/list.go
@@ -17,7 +17,7 @@ func newLsCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			timeout, err := cmd.InheritedFlags().GetDuration("timeout")
 			if err != nil {
-				return fmt.Errorf("download file: get cli parameter 'timeout': %w", err)
+				return fmt.Errorf("list services: get cli parameter 'timeout': %w", err)
 			}
 
 			ctx, cancelFunc := context.WithTimeout(cmd.Context(), timeout)

--- a/cmd/client/cmd/service.go
+++ b/cmd/client/cmd/service.go
@@ -2,11 +2,9 @@ package cmd
 
 import (
 	"fmt"
-	"log"
 	"time"
 
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 const cmdTimeout = 10 * time.Second
@@ -27,10 +25,6 @@ func newServiceCmd() *cobra.Command {
 	serviceFlags.String("address", "localhost:8080", `"translate" service address as "host:port"`)
 	serviceFlags.Bool("insecure", false, `disable transport security (default false)`)
 	serviceFlags.Duration("timeout", cmdTimeout, `command execution timeout`)
-
-	if err := viper.BindPFlags(serviceFlags); err != nil {
-		log.Panicf("service cmd: bind flags: %v", err)
-	}
 
 	serviceCmd.AddCommand(newUploadCmd())
 	serviceCmd.AddCommand(newDownloadCmd())

--- a/cmd/client/cmd/upload.go
+++ b/cmd/client/cmd/upload.go
@@ -65,7 +65,7 @@ func newUploadCmd() *cobra.Command {
 			var data []byte
 
 			if strings.HasPrefix(filePath, "http://") || strings.HasPrefix(filePath, "https://") {
-				if data, err = readFileFromURL(cmd.Context(), filePath); err != nil {
+				if data, err = readFileFromURL(ctx, filePath); err != nil {
 					return fmt.Errorf("upload file: read file from URL: %w", err)
 				}
 			} else {

--- a/cmd/client/cmd/upload.go
+++ b/cmd/client/cmd/upload.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 	translatev1 "go.expect.digital/translate/pkg/pb/translate/v1"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 )
@@ -124,10 +123,6 @@ func newUploadCmd() *cobra.Command {
 
 	if err := uploadCmd.MarkFlagRequired("schema"); err != nil {
 		log.Panicf("upload file cmd: set field 'schema' as required: %v", err)
-	}
-
-	if err := viper.BindPFlags(uploadFlags); err != nil {
-		log.Panicf("upload file cmd: bind flags: %v", err)
 	}
 
 	return uploadCmd

--- a/cmd/client/cmd/upload.go
+++ b/cmd/client/cmd/upload.go
@@ -31,11 +31,6 @@ func newUploadCmd() *cobra.Command {
 			ctx, cancelFunc := context.WithTimeout(cmd.Context(), timeout)
 			defer cancelFunc()
 
-			client, err := newClientConn(ctx, cmd)
-			if err != nil {
-				return fmt.Errorf("upload file: new GRPC client connection: %w", err)
-			}
-
 			serviceID, err := cmd.Flags().GetString("service")
 			if err != nil {
 				return fmt.Errorf("upload file: get cli parameter 'service': %w", err)
@@ -70,7 +65,7 @@ func newUploadCmd() *cobra.Command {
 			var data []byte
 
 			if strings.HasPrefix(filePath, "http://") || strings.HasPrefix(filePath, "https://") {
-				if data, err = readFileFromURL(ctx, filePath); err != nil {
+				if data, err = readFileFromURL(cmd.Context(), filePath); err != nil {
 					return fmt.Errorf("upload file: read file from URL: %w", err)
 				}
 			} else {
@@ -84,7 +79,7 @@ func newUploadCmd() *cobra.Command {
 				return fmt.Errorf("upload file: schema to translate schema: %w", err)
 			}
 
-			if _, err = translatev1.NewTranslateServiceClient(client).UploadTranslationFile(ctx,
+			if _, err = translatev1.NewTranslateServiceClient(conn).UploadTranslationFile(ctx,
 				&translatev1.UploadTranslationFileRequest{
 					Language:             language,
 					Data:                 data,


### PR DESCRIPTION
closes #60 

- Parallelised CLI tests
- Tidy up a little bit
- Removed viper from CLI, as its implementation was incomplete, and its presence adds headache to concurrent testing. (If needed it can be added back, but refactoring will be needed)